### PR TITLE
nes 7.0.1 is required for the code to run

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 gym-super-mario-bros==7.1.6
 tensorboardX==1.6
-tensorflow-gpu==1.13.1
+tensorflow==1.13.1
 torch==1.0.1.post2
 torchvision==0.2.2.post3
 nes_py==7.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 gym-super-mario-bros==7.1.6
 tensorboardX==1.6
-tensorflow==1.13.1
+tensorflow-gpu==1.13.1
 torch==1.0.1.post2
 torchvision==0.2.2.post3
+nes_py==7.0.1


### PR DESCRIPTION
With with 7.0.1 version of nes_py the code doesn't run. New nes_py has BinarySpaceToDiscreteSpaceEnv depreciated and uses JoypadSpace. The current code doesn't work unless nes_py is downgraded from 8.1.1 to 7.0.1. The current code shows following error:
```
from nes_py.wrappers import BinarySpaceToDiscreteSpaceEnv
ImportError: cannot import name 'BinarySpaceToDiscreteSpaceEnv'
```
It can be fixed with downgrade of nes_py to 7.0.1